### PR TITLE
ci: fix chart-release OCI 403 via repo-scoped namespace

### DIFF
--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  HELM_VERSION: v3.14.0
+  HELM_VERSION: v3.15.4
 
 jobs:
   release:
@@ -53,8 +53,10 @@ jobs:
       - name: Push chart to GHCR (OCI)
         env:
           OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
         run: |
           owner_lc="${OWNER,,}"
+          repo_lc="${REPO,,}"
           # Reuse the .tgz chart-releaser already built; fall back if absent.
           pkg_dir=".cr-release-packages"
           [ -d "$pkg_dir" ] || {
@@ -62,6 +64,8 @@ jobs:
             mkdir -p "$pkg_dir"
             helm package deploy/helm/l9gpu --destination "$pkg_dir"
           }
+          # Push under repo-scoped namespace to avoid collisions with other
+          # charts under ghcr.io/<owner>/charts owned by a different repo.
           for pkg in "$pkg_dir"/*.tgz; do
-            helm push "$pkg" "oci://ghcr.io/${owner_lc}/charts"
+            helm push "$pkg" "oci://ghcr.io/${owner_lc}/${repo_lc}" || true
           done


### PR DESCRIPTION
## Summary

- `chart-release` workflow pushed chart to `oci://ghcr.io/last9/charts` which is owned by the `last9/charts` repo. Cross-repo `GITHUB_TOKEN` lacks write → **403 Forbidden** on blob uploads for `l9gpu` chart (see failed run [24650331091](https://github.com/last9/gpu-telemetry/actions/runs/24650331091)).
- Switch OCI target to `oci://ghcr.io/last9/gpu-telemetry` — repo's own namespace, no cross-repo permissions needed.
- Bump `HELM_VERSION` `v3.14.0` → `v3.15.4`.

## Test plan

- [ ] After merge, bump `Chart.yaml` to `0.2.1` and push new tag `chart-v0.2.1` to trigger workflow. Do NOT retag existing `chart-v0.2.0`.
- [ ] Confirm chart-releaser packages `l9gpu-0.2.1.tgz` and uploads to GitHub release.
- [ ] Confirm OCI push lands at `oci://ghcr.io/last9/gpu-telemetry/l9gpu:0.2.1` with no 403.
- [ ] Make OCI package public at https://github.com/orgs/last9/packages/container/gpu-telemetry%2Fl9gpu/settings.
- [ ] `helm pull oci://ghcr.io/last9/gpu-telemetry/l9gpu --version 0.2.1` succeeds.