### PR TITLE
docs: update OCI install path to repo-scoped namespace + v0.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ helm install l9gpu l9gpu/l9gpu -n monitoring --create-namespace \
   --set otlpSecretName=l9gpu-otlp
 
 # or OCI
-helm install l9gpu oci://ghcr.io/last9/charts/l9gpu --version 0.1.0 -n monitoring
+helm install l9gpu oci://ghcr.io/last9/gpu-telemetry/l9gpu --version 0.2.1 -n monitoring
 ```
 
 Create the OTLP secret first:


### PR DESCRIPTION
## Summary

- Update README OCI install command: `ghcr.io/last9/charts/l9gpu:0.1.0` → `ghcr.io/last9/gpu-telemetry/l9gpu:0.2.1`.
- Path changed in #6 to avoid cross-repo ghcr permission 403.

## Test plan

- [ ] Render check.