### PR TITLE
Fix collector release: tag derivation + decouple GitHub release

### DIFF
--- a/.github/workflows/collector-release.yml
+++ b/.github/workflows/collector-release.yml
@@ -67,9 +67,25 @@ jobs:
         id: semver
         env:
           REF_NAME: ${{ github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
         run: |
-          semver="${REF_NAME#collector-}"
+          if [ "$REF_TYPE" = "tag" ]; then
+            tag="$REF_NAME"
+          else
+            # workflow_dispatch / branch run: fall back to the latest collector-v* tag
+            tag="$(git describe --tags --abbrev=0 --match 'collector-v*')"
+          fi
+          if [ -z "$tag" ]; then
+            echo "::error::no collector-v* tag found to release from" >&2
+            exit 1
+          fi
+          # goreleaser (OSS) parses .Version from GORELEASER_CURRENT_TAG, so it
+          # must be a bare semver (v0.2.0) with the "collector-" prefix stripped.
+          # The GitHub release is published separately at the full tag below.
+          semver="${tag#collector-}"
+          echo "Releasing ${semver} (from ${tag})"
           echo "tag=${semver}" >> "$GITHUB_OUTPUT"
+          echo "full_tag=${tag}" >> "$GITHUB_OUTPUT"
 
       - name: Run goreleaser
         uses: goreleaser/goreleaser-action@v6
@@ -80,3 +96,24 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ steps.semver.outputs.tag }}
+
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          FULL_TAG: ${{ steps.semver.outputs.full_tag }}
+          SEMVER: ${{ steps.semver.outputs.tag }}
+        run: |
+          # goreleaser left the archives + checksums in dist/ (release.disable).
+          # Publish them at the namespaced collector-vX.Y.Z tag, idempotently so
+          # re-runs of the same tag re-upload instead of failing.
+          prerelease_flag=""
+          case "$SEMVER" in *-*) prerelease_flag="--prerelease" ;; esac
+          if gh release view "$FULL_TAG" >/dev/null 2>&1; then
+            gh release upload "$FULL_TAG" dist/*.tar.gz dist/checksums.txt --clobber
+          else
+            gh release create "$FULL_TAG" \
+              --title "l9gpu-collector ${SEMVER#v}" \
+              --generate-notes \
+              $prerelease_flag \
+              dist/*.tar.gz dist/checksums.txt
+          fi

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -75,13 +75,13 @@ docker_manifests:
 checksum:
   name_template: "checksums.txt"
 
+# goreleaser only builds the binaries/archives and pushes the docker image.
+# The GitHub release is published by the workflow via `gh release create` at
+# the full "collector-vX.Y.Z" tag. We can't let goreleaser publish it because
+# goreleaser (OSS) derives the release tag from the parsed semver (v0.2.0),
+# which is also owned by the Python release — they would collide.
 release:
-  github:
-    owner: last9
-    name: gpu-telemetry
-  prerelease: auto
-  draft: false
-  name_template: "l9gpu-collector {{ .Version }}"
+  disable: "true"
 
 changelog:
   sort: asc

--- a/docs/COLLECTOR.md
+++ b/docs/COLLECTOR.md
@@ -27,11 +27,12 @@ docker run --rm \
 Use `:latest` for tracking the newest release, or pin to a version:
 
 ```bash
-docker pull ghcr.io/last9/l9gpu-collector:collector-v0.1.0
+docker pull ghcr.io/last9/l9gpu-collector:v0.1.0
 ```
 
-Multi-arch (linux/amd64, linux/arm64). Docker picks the right image
-automatically.
+The docker image is published for `linux/amd64` only. For `linux/arm64`,
+use the binary tarball below (a native arm64 image will be added once an
+arm64 build runner is available).
 
 ### Kubernetes
 


### PR DESCRIPTION
## Why

`collector-release.yml` failed. Two distinct problems surfaced across the failed runs, plus a latent third:

1. **GHCR push denied** (the active blocker): `denied: permission_denied: write_package` pushing `ghcr.io/last9/l9gpu-collector`. The package doesn't exist yet and `GITHUB_TOKEN` is refused creation rights under the `last9` org. **This is an org-settings fix, not code** — see below.
2. **Tag derivation broke on `workflow_dispatch`**: `github.ref_name` is `main`, so `GORELEASER_CURRENT_TAG` became `main`, producing a `:main-amd64` image.
3. **Release-tag collision** (latent): goreleaser (OSS) derives the GitHub release tag from the parsed semver (`v0.2.0`), which is already owned by the Python `release.yml`. Both `collector-v0.2.0` and `v0.2.0` point at the same commit, so collector artifacts would be attached to the Python release.

## Changes

- **Tag derivation**: use the tag on a tag push; fall back to the latest `collector-v*` tag on `workflow_dispatch`/branch runs (fail loudly if none).
- **Decouple the GitHub release**: set `release.disable` in `.goreleaser.yml` and publish archives + checksums via `gh release create` at the namespaced `collector-vX.Y.Z` tag (idempotent on re-runs). goreleaser still builds binaries and pushes the docker image. (`monorepo.tag_prefix`, the clean fix, is goreleaser **Pro-only** and rejected by the OSS build CI uses.)
- **Docs** (`docs/COLLECTOR.md`): correct the pinned docker tag format (no `collector-` prefix on the image tag) and the multi-arch claim (image is amd64-only; arm64 ships as a binary tarball).

## Still required (out of band, org admin)

The GHCR `permission_denied` is **not** fixed by this PR. An org owner must allow Actions to create/write the `l9gpu-collector` package (Org → Settings → Actions → workflow permissions = read/write, and package creation enabled), or pre-create the package and grant `last9/gpu-telemetry` Write under the package's Actions access.

## Validation

- `.goreleaser.yml` validated with `goreleaser check` (OSS, `~> v2`) — passes (release pipe skipped as intended).
- Workflow YAML parses.