### PR TITLE
Add last9.io project URLs and attribution to l9gpu

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 [![PyPI](https://img.shields.io/pypi/v/l9gpu)](https://pypi.org/project/l9gpu/)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/l9gpu)](https://artifacthub.io/packages/search?repo=l9gpu)
 
+Built by [Last9](https://last9.io) — send GPU telemetry to Last9 or any OTLP backend. See the [Last9 docs](https://docs.last9.io).
+
 DCGM exporter tells you a GPU is hot. It won't tell you whose job is frying it.
 
 Most GPU observability stops at the hardware — utilization, temperature, ECC —

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![PyPI](https://img.shields.io/pypi/v/l9gpu)](https://pypi.org/project/l9gpu/)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/l9gpu)](https://artifacthub.io/packages/search?repo=l9gpu)
 
-Built by [Last9](https://last9.io) — send GPU telemetry to Last9 or any OTLP backend. See the [Last9 docs](https://docs.last9.io).
+Built by [Last9](https://last9.io) — send GPU telemetry to Last9 or any OTLP backend. See the [Last9 docs](https://last9.io/docs/).
 
 DCGM exporter tells you a GPU is hot. It won't tell you whose job is frying it.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ license = { text = "MIT" }
 
 [project.urls]
 Homepage = "https://last9.io"
-Documentation = "https://docs.last9.io"
+Documentation = "https://last9.io/docs/"
 Source = "https://github.com/last9/gpu-telemetry"
 Issues = "https://github.com/last9/gpu-telemetry/issues"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,10 @@ dynamic = ["version"]
 license = { text = "MIT" }
 
 [project.urls]
-Homepage = "https://github.com/last9/gpu-telemetry"
+Homepage = "https://last9.io"
+Documentation = "https://docs.last9.io"
+Source = "https://github.com/last9/gpu-telemetry"
+Issues = "https://github.com/last9/gpu-telemetry/issues"
 
 [project.optional-dependencies]
 amd = ["amdsmi"]


### PR DESCRIPTION
## What

- Point the `[project.urls]` **Homepage** at https://last9.io and add a **Documentation** link to https://docs.last9.io; keep the GitHub repo as **Source**/**Issues**.
- Add a one-line "Built by Last9" attribution near the top of the README linking last9.io and docs.last9.io.

## Why

l9gpu's PyPI project page currently links only to GitHub, so it doesn't surface the backend it ships telemetry to. This matches our other OTel packages (`last9-genai` links last9.io) and gives users a path from the package page to setup docs.

## Effect

Metadata-only; no code or dependency changes. Renders as sidebar links on the [PyPI page](https://pypi.org/project/l9gpu/) at the next tagged release (`v0.2.1`).